### PR TITLE
prevent doLoginRequest from being called every time

### DIFF
--- a/http-login-packaged/pkg/api/init.go
+++ b/http-login-packaged/pkg/api/init.go
@@ -20,7 +20,7 @@ func New(options Options) APIIface {
 	return api{
 		Options: options,
 		Client: http.Client{
-			Transport: MyJWTTransport{
+			Transport: &MyJWTTransport{
 				transport: http.DefaultTransport,
 				password:  options.Password,
 				loginURL:  options.LoginURL,

--- a/http-login-packaged/pkg/api/transport.go
+++ b/http-login-packaged/pkg/api/transport.go
@@ -11,7 +11,7 @@ type MyJWTTransport struct {
 	loginURL  string
 }
 
-func (m MyJWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *MyJWTTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if m.token == "" {
 		if m.password != "" {
 			token, err := doLoginRequest(http.Client{}, m.loginURL, m.password)


### PR DESCRIPTION
in my opinion,  'm.token == "" ' statement is always true.
RoundTrip receiver must be pointer type to prevent doLoginRequest method from being called multiple times