### PR TITLE
Improve rootServers test

### DIFF
--- a/dns-start/pkg/dns/resolver_test.go
+++ b/dns-start/pkg/dns/resolver_test.go
@@ -80,10 +80,13 @@ func TestOutgoingDnsQuery(t *testing.T) {
 		Type:  dnsmessage.TypeNS,
 		Class: dnsmessage.ClassINET,
 	}
-	rootServers := strings.Split(ROOT_SERVERS, ",")
-	if len(rootServers) == 0 {
+
+	if len(ROOT_SERVERS) == 0 {
 		t.Fatalf("No root servers found")
 	}
+
+	rootServers := strings.Split(ROOT_SERVERS, ",")
+
 	servers := []net.IP{net.ParseIP(rootServers[0])}
 	dnsAnswer, header, err := outgoingDnsQuery(servers, question)
 	if err != nil {


### PR DESCRIPTION
Thanks for the course @wardviaene!

I don't think the check on `rootServers` is useful as written
```
rootServers := strings.Split(ROOT_SERVERS, ",")
if len(rootServers) == 0 {
  t.Fatalf("No root servers found")
}
```
If `ROOT_SERVERS` is undefined the build will fail.

If it's defined, but empty, i.e. `const ROOT_SERVERS = ""`, than `strings.Split(ROOT_SERVERS, ",")` will return an array with the single empty element, and the check will still pass.

Here I'm updating the test to check `len(ROOT_SERVERS)`

Cheers,
Mike